### PR TITLE
fix default line height of sup tag, reader mode

### DIFF
--- a/android/app/src/main/assets/css/index.css
+++ b/android/app/src/main/assets/css/index.css
@@ -42,6 +42,10 @@ a {
   color: var(--theme-primary);
 }
 
+sup {
+  line-height: 0.1em;
+}
+
 img {
   display: block;
   width: auto;


### PR DESCRIPTION
![76ghjAgg](https://github.com/user-attachments/assets/80293acf-3610-4706-b057-35b3eff48d1d)

Whenever ``sup`` is used, it adds futher line-height uselessly. So I set it to 0.1em, just enough to add it when it overlays