### PR TITLE
Allow "details" and "summary" html tags in the sanitizer

### DIFF
--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -18,6 +18,8 @@ export const sanitizeChapterText = (
       'ol',
       'li',
       'title',
+      'details',
+      'summary',
     ]),
     allowedAttributes: {
       a: ['href', 'class', 'id'],


### PR DESCRIPTION
In cases a plugin need to have a collapsible piece, like on Royalroad "Author’s Note", or maybe eventual chapter comments, if someone likes them.