### PR TITLE
Fixes the creation of epub

### DIFF
--- a/src/screens/novel/components/EpubIconButton.tsx
+++ b/src/screens/novel/components/EpubIconButton.tsx
@@ -157,7 +157,9 @@ const EpubIconButton: React.FC<EpubIconButtonProps> = ({
           const urlMatcher = new RegExp(regexString, 'g');
           for (const match of downloaded.matchAll(urlMatcher)) {
             const path = match[1];
+
             if (!path) continue;
+
             if (!NativeFile.exists(path)) {
               const figureMatcher = new RegExp(`<figure.*?${path}.*?</figure>`);
               downloaded = downloaded.replace(figureMatcher, '');


### PR DESCRIPTION
Saving epub would sometimes fail if the src file in the figure tag in the downloaded chapter does not exist.