### PR TITLE
Plugin repo API version check & warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
         "react-native-drawer-layout": "^4.1.8",
         "react-native-edge-to-edge": "^1.6.0",
         "react-native-error-boundary": "^2.0.0",
-        "react-native-fast-scroll": "^0.3.2",
         "react-native-file-access": "^3.2.0",
         "react-native-gesture-handler": "~2.25.0",
         "react-native-lottie-splash-screen": "^1.1.2",
@@ -154,7 +153,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -186,7 +184,6 @@
       "integrity": "sha512-q8rjOuadH0V6Zo4XLMkJ3RMQ9MSBqwaDByyYB0izsYdaIWGNLmEblbCOf1vyFHICcg16CD7Fsi51vcQnYxmt6Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",
@@ -2130,7 +2127,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
       "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -3972,7 +3968,6 @@
       "integrity": "sha512-DyKptlG78XPFo7tDod+we5a3R+U9qjyhaVFbOPvH4pFNu5Dehewtol/srl44K6Cszq0aEMlAJZ3juk0W4WnOJA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-native-community/cli-clean": "18.0.0",
         "@react-native-community/cli-config": "18.0.0",
@@ -4750,7 +4745,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.8.tgz",
       "integrity": "sha512-ryKd/qNigi1pUp6mBb2pq75ese7AZ/Cl3xEmTG6PcUGMfMqAMMrmmVbgiys0h8zCGY2tSBSqnDHbGW1/ZtOoKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.9.1",
         "escape-string-regexp": "^4.0.0",
@@ -4818,18 +4812,6 @@
       },
       "engines": {
         "node": ">=12.5.0"
-      }
-    },
-    "node_modules/@shopify/flash-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@shopify/flash-list/-/flash-list-2.1.0.tgz",
-      "integrity": "sha512-/EIQlptG456yM5o9qNmNsmaZEFEOGvG3WGyb6GUAxSLlcKUGlPUkPI2NLW5wQSDEY4xSRa5zocUI+9xwmsM4Kg==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/@sideway/address": {
@@ -5031,8 +5013,8 @@
       "version": "19.1.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.3.tgz",
       "integrity": "sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==",
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5101,7 +5083,6 @@
       "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "7.18.0",
@@ -5136,7 +5117,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -5373,12 +5353,6 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/abs-svg-path": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
-      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
-      "license": "MIT"
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -5406,7 +5380,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6295,7 +6268,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -7013,6 +6985,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -7664,7 +7637,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8332,7 +8304,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.9.tgz",
       "integrity": "sha512-UFG68aVOpccg3s++S3pbtI3YCQCnlu/TFvhnQ5vaD3vhOox1Uk/f2O2T95jmwA/EvKvetqGj34lys3DNXvPqgQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "0.24.13",
@@ -8449,7 +8420,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-13.3.1.tgz",
       "integrity": "sha512-d+xrHYvSM9WB42wj8vP9OOFWyxed5R1evphfDb6zYBmC1dA9Hf89FpT7TNFtj2Bk3clTnpmVqQTCYbbA2P3CLg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -8639,6 +8609,16 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo/node_modules/babel-plugin-react-compiler": {
+      "version": "19.0.0-beta-ebf51a3-20250411",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-19.0.0-beta-ebf51a3-20250411.tgz",
+      "integrity": "sha512-q84bNR9JG1crykAlJUt5Ud0/5BUyMFuQww/mrwIQDFBaxsikqBDj3f/FNDsVd2iR26A1HvXKWPEIfgJDv8/V2g==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.26.0"
       }
     },
     "node_modules/expo/node_modules/babel-preset-expo": {
@@ -11480,8 +11460,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/lottie-ios/-/lottie-ios-3.2.3.tgz",
       "integrity": "sha512-mubYMN6+1HXa8z3EJKBvNBkl4UoVM4McjESeB2PgvRMSngmJtC5yUMRdhbbrIAn5Liu3hFGao/14s5hQIgtkRQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -12196,15 +12175,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/normalize-svg-path": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
-      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
-      "license": "MIT",
-      "dependencies": {
-        "svg-arc-to-cubic-bezier": "^3.0.0"
-      }
-    },
     "node_modules/npm-package-arg": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
@@ -12645,12 +12615,6 @@
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
       "license": "MIT"
     },
-    "node_modules/parse-svg-path": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
-      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
-      "license": "MIT"
-    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -12957,7 +12921,6 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -13075,7 +13038,6 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -13260,7 +13222,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13319,7 +13280,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.2.tgz",
       "integrity": "sha512-AnGzb56JvU5YCL7cAwg10+ewDquzvmgrMddiBM0GAWLwQM/6DJfGd2ZKrMuKKehHerpDDZgG+EY64gk3x3dEkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.79.2",
@@ -13467,27 +13427,6 @@
         }
       }
     },
-    "node_modules/react-native-fast-scroll": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/react-native-fast-scroll/-/react-native-fast-scroll-0.3.2.tgz",
-      "integrity": "sha512-ylOx1OQT1aqX71b03JqNJ4Xg3RoeSeAh2WNVkqS2hN67qYfrh1ziZktLG9e0dBLjCbxI9UZjMxS22xKZ/mL94g==",
-      "license": "MIT",
-      "dependencies": {
-        "throttle-debounce": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "peerDependencies": {
-        "@shopify/flash-list": "*",
-        "@types/react": "*",
-        "react": "*",
-        "react-native": "*",
-        "react-native-gesture-handler": ">=2.8.0",
-        "react-native-reanimated": ">=2.12.0",
-        "react-native-redash": "*"
-      }
-    },
     "node_modules/react-native-file-access": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-native-file-access/-/react-native-file-access-3.2.0.tgz",
@@ -13503,7 +13442,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.25.0.tgz",
       "integrity": "sha512-NPjJi6mislXxvjxQPU9IYwBjb1Uejp8GvAbE1Lhh+xMIMEvmgAvVIp5cz1P+xAbV6uYcRRArm278+tEInGOqWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -13584,7 +13522,6 @@
       "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-6.7.1.tgz",
       "integrity": "sha512-cBSr6xw4g5N7Kd3VGWcf+kmaH7iBWb0DXAf2bVo3bXkzBcBbTOmYSvc0LVLHhUPW8nEq5WjT9LCIYAzgF++EXw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -13640,7 +13577,6 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.5.tgz",
       "integrity": "sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -13661,24 +13597,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/react-native-redash": {
-      "version": "18.1.4",
-      "resolved": "https://registry.npmjs.org/react-native-redash/-/react-native-redash-18.1.4.tgz",
-      "integrity": "sha512-0afzhj+ZQHNYfzwSPTssFU+TEcsZ6hnZkhDJfmgWCIXwcELMAtWE8UD21jeiZ2EeHiy6a/3OlT1uwANtsvthog==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "abs-svg-path": "^0.1.1",
-        "normalize-svg-path": "^1.0.1",
-        "parse-svg-path": "^0.1.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*",
-        "react-native-gesture-handler": "*",
-        "react-native-reanimated": ">=2.0.0"
-      }
-    },
     "node_modules/react-native-saf-x": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-native-saf-x/-/react-native-saf-x-2.2.3.tgz",
@@ -13694,7 +13612,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz",
       "integrity": "sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -13717,7 +13634,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.10.0.tgz",
       "integrity": "sha512-Tw21NGuXm3PbiUGtZd0AnXirUixaAbPXDjNR0baBH7/WJDaDTTELLcQ7QRXuqAWbmr/EVCrKj1348ei1KFIr8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
@@ -13768,7 +13684,6 @@
       "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.13.5.tgz",
       "integrity": "sha512-MfC2B+woL4Hlj2WCzcb1USySKk+SteXnUKmKktOk/H/AQy5+LuVdkPKm8SknJ0/RxaxhZ48WBoTRGaqgR137hw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
@@ -15276,12 +15191,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/svg-arc-to-cubic-bezier": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
-      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
-      "license": "ISC"
-    },
     "node_modules/tar": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
@@ -15441,15 +15350,6 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "license": "MIT"
-    },
-    "node_modules/throttle-debounce": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
-      "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.22"
-      }
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -15666,7 +15566,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/components/IconButtonV2/IconButtonV2.tsx
+++ b/src/components/IconButtonV2/IconButtonV2.tsx
@@ -10,7 +10,7 @@ type Props = {
   name: MaterialDesignIconName;
   color?: string;
   size?: number;
-  disabled?: boolean;
+  disabled?: boolean | 'visible';
   padding?: number;
   onPress?: () => void;
   theme: ThemeColors;
@@ -31,7 +31,7 @@ const IconButton: React.FC<Props> = ({
     <Pressable
       style={[styles.pressable, { padding }]}
       onPress={onPress}
-      disabled={disabled}
+      disabled={(disabled === true)}
       android_ripple={
         onPress
           ? { color: Color(theme.primary).alpha(0.12).string() }
@@ -41,7 +41,7 @@ const IconButton: React.FC<Props> = ({
       <MaterialCommunityIcons
         name={name}
         size={size}
-        color={disabled ? theme.outline : color || theme.onSurface}
+        color={disabled !== false ? theme.outline : color || theme.onSurface}
       />
     </Pressable>
   </View>

--- a/src/hooks/persisted/usePlugins.ts
+++ b/src/hooks/persisted/usePlugins.ts
@@ -71,14 +71,15 @@ export default function usePlugins() {
       getMMKVObject<PluginItem[]>(INSTALLED_PLUGINS) || [];
     return fetchPlugins().then(fetchedPlugins => {
       fetchedPlugins.filter(plg => {
-        const finded = installedPlugins.find(v => v.id === plg.id);
-        if (finded) {
-          if (newer(plg.version, finded.version)) {
-            finded.hasUpdate = true;
-            finded.iconUrl = plg.iconUrl;
-            finded.url = plg.url;
-            if (finded.id === lastUsedPlugin?.id) {
-              setLastUsedPlugin(finded);
+        const found = installedPlugins.find(v => v.id === plg.id);
+        if (found) {
+          found.updateApi = plg.api;
+          if (newer(plg.version, found.version)) {
+            found.hasUpdate = true;
+            found.iconUrl = plg.iconUrl;
+            found.url = plg.url;
+            if (found.id === lastUsedPlugin?.id) {
+              setLastUsedPlugin(found);
             }
           }
           return false;

--- a/src/plugins/types/index.ts
+++ b/src/plugins/types/index.ts
@@ -57,6 +57,20 @@ export interface PluginItem {
   customCSS?: string;
   hasUpdate?: boolean;
   hasSettings?: boolean;
+
+  /**
+   * The API version against which the plugin is developed.
+   * This allows older version of LNReader to prevent the
+   * installation of plugins developed after breaking changes
+   * to the plugin API.
+   * 
+   * Non-breaking, optional additions to the API do not require
+   * a version bump. This should only be used if an older version
+   * of LNReader would not be able to understand the plugin's
+   * API without adaptation.
+   */
+  api?: string;
+  updateApi?: string;
 }
 
 export interface ImageRequestInit {

--- a/src/screens/browse/components/DeferredPluginListItem.tsx
+++ b/src/screens/browse/components/DeferredPluginListItem.tsx
@@ -13,6 +13,7 @@ interface DeferredPluginListItemProps {
   theme: ThemeColors;
   navigation: BrowseScreenProps['navigation'];
   settingsModal: UseBooleanReturnType;
+  pluginIncompatibleModal: UseBooleanReturnType;
   navigateToSource: (plugin: PluginItem, showLatestNovels?: boolean) => void;
   setSelectedPluginId: React.Dispatch<React.SetStateAction<string>>;
 }

--- a/src/screens/browse/components/InstalledTab.tsx
+++ b/src/screens/browse/components/InstalledTab.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo, useState, memo } from 'react';
 import { Text, StyleSheet } from 'react-native';
-import { Portal } from 'react-native-paper';
 import { LegendList, LegendListRenderItemProps } from '@legendapp/list';
 
 import { useBrowseSettings, usePlugins } from '@hooks/persisted';
@@ -12,8 +11,9 @@ import { useBoolean } from '@hooks';
 import { getPlugin } from '@plugins/pluginManager';
 
 import DiscoverCard from '../discover/DiscoverCard';
-import SourceSettingsModal from './Modals/SourceSettings';
+import SourceSettingsModal from './Modals/SourceSettingsModal';
 import { DeferredPluginListItem } from './DeferredPluginListItem';
+import PluginIncompatibleModal from './Modals/PluginIncompatibleModal';
 
 interface InstalledTabProps {
   navigation: BrowseScreenProps['navigation'];
@@ -31,7 +31,12 @@ export const InstalledTab = memo(
     } = usePlugins();
     const { showMyAnimeList, showAniList } = useBrowseSettings();
     const settingsModal = useBoolean();
+    const pluginIncompatibleModal = useBoolean();
     const [selectedPluginId, setSelectedPluginId] = useState<string>('');
+
+    const selectedPlugin = useMemo(() =>
+        (selectedPluginId && filteredInstalledPlugins.find(plg => plg.id === selectedPluginId)) ?? null,
+      [selectedPluginId]);
 
     const pluginSettings = selectedPluginId
       ? getPlugin(selectedPluginId)?.pluginSettings
@@ -92,12 +97,13 @@ export const InstalledTab = memo(
             theme={theme}
             navigation={navigation}
             settingsModal={settingsModal}
+            pluginIncompatibleModal={pluginIncompatibleModal}
             navigateToSource={navigateToSource}
             setSelectedPluginId={setSelectedPluginId}
           />
         );
       },
-      [theme, navigation, navigateToSource, settingsModal],
+      [theme, navigation, navigateToSource, setSelectedPluginId, settingsModal, pluginIncompatibleModal],
     );
 
     return (
@@ -153,6 +159,7 @@ export const InstalledTab = memo(
                     theme={theme}
                     navigation={navigation}
                     settingsModal={settingsModal}
+                    pluginIncompatibleModal={pluginIncompatibleModal}
                     navigateToSource={navigateToSource}
                     setSelectedPluginId={setSelectedPluginId}
                   />
@@ -175,6 +182,7 @@ export const InstalledTab = memo(
                   theme={theme}
                   navigation={navigation}
                   settingsModal={settingsModal}
+                  pluginIncompatibleModal={pluginIncompatibleModal}
                   navigateToSource={navigateToSource}
                   setSelectedPluginId={setSelectedPluginId}
                 />
@@ -190,16 +198,20 @@ export const InstalledTab = memo(
                 : getString('browseScreen.installedPlugins')}
             </Text>
 
-            <Portal>
-              <SourceSettingsModal
-                visible={settingsModal.value}
-                onDismiss={settingsModal.setFalse}
-                title={getString('browseScreen.settings.title')}
-                description={getString('browseScreen.settings.description')}
-                pluginId={selectedPluginId}
-                pluginSettings={pluginSettings}
-              />
-            </Portal>
+            <SourceSettingsModal
+              visible={settingsModal.value}
+              onDismiss={settingsModal.setFalse}
+              title={getString('browseScreen.settings.title')}
+              description={getString('browseScreen.settings.description')}
+              pluginId={selectedPluginId}
+              pluginSettings={pluginSettings}
+            />
+            {selectedPlugin && <PluginIncompatibleModal
+              update={true}
+              visible={pluginIncompatibleModal.value}
+              onDismiss={pluginIncompatibleModal.setFalse}
+              plugin={selectedPlugin}
+            />}
           </>
         }
       />

--- a/src/screens/browse/components/Modals/PluginIncompatibleModal.tsx
+++ b/src/screens/browse/components/Modals/PluginIncompatibleModal.tsx
@@ -1,0 +1,76 @@
+import { Button, Modal } from '@components/index';
+import { useTheme } from '@hooks/persisted';
+import { PluginItem } from '@plugins/types';
+import { getString } from '@strings/translations';
+import { Links } from '@utils/constants/links';
+import { Linking, StyleSheet, Text, View } from 'react-native';
+import { Portal } from 'react-native-paper';
+
+interface PluginIncompatibleModalProps {
+  plugin: PluginItem;
+  visible: boolean;
+  onDismiss: () => void;
+  update?: boolean;
+}
+
+const PluginIncompatibleModal: React.FC<PluginIncompatibleModalProps> = ({plugin, visible, onDismiss, update = false}) => {
+  const theme = useTheme();
+  
+  const apiStr = (update ? plugin.updateApi : plugin.api) ?? '1.0.0';
+  
+  return (
+    <Portal>
+      <Modal visible={visible} onDismiss={onDismiss}>
+        <Text style={[styles.modalTitle, { color: theme.onSurface }]}>
+          {getString(update ? 'browseScreen.incompatible.updateTitle' : 'browseScreen.incompatible.installTitle')}
+        </Text>
+        <Text style={[styles.modalBodyText, { color: theme.onSurfaceVariant }]}>
+          {getString(update ? 'browseScreen.incompatible.updateText1' : 'browseScreen.incompatible.installText1')}
+          <Text style={{ fontWeight: 'bold' }}>"{plugin.name}"</Text>
+          {getString('browseScreen.incompatible.text2')}
+          <Text style={{ fontWeight: 'bold' }}>{apiStr}</Text>
+          {getString('browseScreen.incompatible.text3')}
+        </Text>
+        {Links.pluginCompatibilityTable && <Text style={[styles.modalBodyText,{ color: theme.onSurfaceVariant, marginTop: 8 }]}>
+          {getString('browseScreen.incompatible.text4')}
+          <Text style={[{ color: theme.primary, textDecorationLine: 'underline' }]}
+            onPress={() => Links.pluginCompatibilityTable &&
+              Linking.openURL(Links.pluginCompatibilityTable)}>{getString('browseScreen.incompatible.text5')}
+          </Text>
+          {getString('browseScreen.incompatible.text6')}
+        </Text>}
+        <View style={styles.customCSSButtons}>
+          <Button
+            onPress={onDismiss}
+            style={styles.button}
+            title={"Close"}
+            mode="contained"
+          />
+        </View>
+      </Modal>
+    </Portal>
+  );
+}
+
+export default PluginIncompatibleModal;
+
+
+const styles = StyleSheet.create({
+  button: {
+    flex: 1,
+    marginHorizontal: 8,
+    marginTop: 16,
+  },
+  customCSSButtons: {
+    flexDirection: 'row',
+  },
+  modalTitle: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+  modalBodyText: {
+    fontSize: 15,
+    lineHeight: 18,
+    marginBottom: 16,
+  },
+});

--- a/src/screens/browse/components/Modals/SourceSettingsModal.tsx
+++ b/src/screens/browse/components/Modals/SourceSettingsModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { TextInput } from 'react-native-paper';
+import { Portal, TextInput } from 'react-native-paper';
 import { Button, Modal, SwitchItem } from '@components/index';
 import { useTheme } from '@hooks/persisted';
 import { getString } from '@strings/translations';
@@ -16,7 +16,7 @@ interface PluginSettings {
   [key: string]: PluginSetting;
 }
 
-interface SourceSettingsModal {
+interface SourceSettingsModalProps {
   visible: boolean;
   onDismiss: () => void;
   title: string;
@@ -25,7 +25,7 @@ interface SourceSettingsModal {
   pluginSettings?: PluginSettings;
 }
 
-const SourceSettingsModal: React.FC<SourceSettingsModal> = ({
+const SourceSettingsModal: React.FC<SourceSettingsModalProps> = ({
   onDismiss,
   visible,
   title,
@@ -83,59 +83,63 @@ const SourceSettingsModal: React.FC<SourceSettingsModal> = ({
 
   if (!pluginSettings || Object.keys(pluginSettings).length === 0) {
     return (
-      <Modal visible={visible} onDismiss={onDismiss}>
-        <Text style={[styles.modalTitle, { color: theme.onSurface }]}>
-          {title}
-        </Text>
-        <Text style={{ color: theme.onSurfaceVariant }}>
-          {description || 'No settings available.'}
-        </Text>
-      </Modal>
+      <Portal>
+        <Modal visible={visible} onDismiss={onDismiss}>
+          <Text style={[styles.modalTitle, { color: theme.onSurface }]}>
+            {title}
+          </Text>
+          <Text style={{ color: theme.onSurfaceVariant }}>
+            {description || 'No settings available.'}
+          </Text>
+        </Modal>
+      </Portal>
     );
   }
 
   return (
-    <Modal visible={visible} onDismiss={onDismiss}>
-      <Text style={[styles.modalTitle, { color: theme.onSurface }]}>
-        {title}
-      </Text>
-      <Text style={{ color: theme.onSurfaceVariant }}>{description}</Text>
-      {Object.entries(pluginSettings).map(([key, setting]) => {
-        if (setting?.type === 'Switch') {
+    <Portal>
+      <Modal visible={visible} onDismiss={onDismiss}>
+        <Text style={[styles.modalTitle, { color: theme.onSurface }]}>
+          {title}
+        </Text>
+        <Text style={{ color: theme.onSurfaceVariant }}>{description}</Text>
+        {Object.entries(pluginSettings).map(([key, setting]) => {
+          if (setting?.type === 'Switch') {
+            return (
+              <SwitchItem
+                key={key}
+                value={!!formValues[key]}
+                label={setting.label}
+                onPress={() => handleChange(key, !formValues[key])}
+                theme={theme}
+              />
+            );
+          }
           return (
-            <SwitchItem
+            <TextInput
               key={key}
-              value={!!formValues[key]}
+              mode="outlined"
               label={setting.label}
-              onPress={() => handleChange(key, !formValues[key])}
-              theme={theme}
+              value={(formValues[key] ?? '') as string}
+              onChangeText={value => handleChange(key, value)}
+              placeholder={`Enter ${setting.label}`}
+              placeholderTextColor={theme.onSurfaceDisabled}
+              underlineColor={theme.outline}
+              style={[{ color: theme.onSurface }, styles.textInput]}
+              theme={{ colors: { ...theme } }}
             />
           );
-        }
-        return (
-          <TextInput
-            key={key}
-            mode="outlined"
-            label={setting.label}
-            value={(formValues[key] ?? '') as string}
-            onChangeText={value => handleChange(key, value)}
-            placeholder={`Enter ${setting.label}`}
-            placeholderTextColor={theme.onSurfaceDisabled}
-            underlineColor={theme.outline}
-            style={[{ color: theme.onSurface }, styles.textInput]}
-            theme={{ colors: { ...theme } }}
+        })}
+        <View style={styles.customCSSButtons}>
+          <Button
+            onPress={handleSave}
+            style={styles.button}
+            title={getString('common.save')}
+            mode="contained"
           />
-        );
-      })}
-      <View style={styles.customCSSButtons}>
-        <Button
-          onPress={handleSave}
-          style={styles.button}
-          title={getString('common.save')}
-          mode="contained"
-        />
-      </View>
-    </Modal>
+        </View>
+      </Modal>
+    </Portal>
   );
 };
 

--- a/src/screens/more/About.tsx
+++ b/src/screens/more/About.tsx
@@ -11,6 +11,8 @@ import { AboutScreenProps } from '@navigators/types';
 import { GIT_HASH, RELEASE_DATE, BUILD_TYPE } from '@env';
 import * as Clipboard from 'expo-clipboard';
 import { version } from '../../../package.json';
+import { Links } from '@utils/constants/links';
+import { StringMap } from '@strings/types';
 
 const AboutScreen = ({ navigation }: AboutScreenProps) => {
   const theme = useTheme();
@@ -57,42 +59,22 @@ const AboutScreen = ({ navigation }: AboutScreenProps) => {
             theme={theme}
           />
           <List.Divider theme={theme} />
-          <List.Item
-            title={getString('aboutScreen.website')}
-            description="https://lnreader.github.io"
-            onPress={() => Linking.openURL('https://lnreader.github.io')}
-            theme={theme}
-          />
-          <List.Item
-            title={getString('aboutScreen.discord')}
-            description="https://discord.gg/QdcWN4MD63"
-            onPress={() => Linking.openURL('https://discord.gg/QdcWN4MD63')}
-            theme={theme}
-          />
-          <List.Item
-            title={getString('aboutScreen.github')}
-            description="https://github.com/LNReader/lnreader"
-            onPress={() =>
-              Linking.openURL('https://github.com/LNReader/lnreader')
-            }
-            theme={theme}
-          />
-          <List.Item
-            title={getString('aboutScreen.sources')}
-            description="https://github.com/LNReader/lnreader-sources"
-            onPress={() =>
-              Linking.openURL('https://github.com/LNReader/lnreader-sources')
-            }
-            theme={theme}
-          />
-          <List.Item
-            title={getString('aboutScreen.helpTranslate')}
-            description="https://crowdin.com/project/lnreader"
-            onPress={() =>
-              Linking.openURL('https://crowdin.com/project/lnreader')
-            }
-            theme={theme}
-          />
+          {
+            Object.entries({
+              'aboutScreen.website': Links.officialSite,
+              'aboutScreen.discord': Links.discord,
+              'aboutScreen.github': Links.github,
+              'aboutScreen.sources': Links.officialPluginRepo,
+              'aboutScreen.helpTranslate': Links.crowdin,
+            } as Record<keyof StringMap, string>).map(([title, url]) => (
+              <List.Item
+                key={title}
+                title={getString(title as keyof StringMap)}
+                onPress={() => Linking.openURL(url)}
+                theme={theme}
+              />
+            ))
+          }
         </List.Section>
       </ScrollView>
     </SafeAreaView>

--- a/src/utils/constants/links.ts
+++ b/src/utils/constants/links.ts
@@ -1,0 +1,8 @@
+export const Links = {
+  officialSite: 'https://lnreader.app',
+  discord: 'https://discord.gg/QdcWN4MD63',
+  github: 'https://github.com/LNReader/lnreader',
+  officialPluginRepo: 'https://github.com/LNReader/lnreader-plugins/',
+  crowdin: 'https://crowdin.com/project/lnreader',
+  pluginCompatibilityTable:  __DEV__ ? 'https://lnreader.app/plugins' : null,
+}

--- a/strings/languages/en/strings.json
+++ b/strings/languages/en/strings.json
@@ -143,6 +143,18 @@
     "settings": {
       "title": "Plugin Settings",
       "description": "Fill in the plugin settings. Restart app to apply the settings."
+    },
+    "incompatible": {
+      "append": " (unsupported)",
+      "updateTitle": "Update incompatible",
+      "installTitle": "Plugin incompatible",
+      "updateText1": "The latest version of ",
+      "installText1": "The plugin ",
+      "text2": " was developed for API version ",
+      "text3": ", which is not yet supported by this version of LNReader. To install this plugin, you need to update the app.",
+      "text4": "See the ",
+      "text5": "compatibility table",
+      "text6": " for more information."
     }
   },
   "browseSettings": "Browse Settings",

--- a/strings/types/index.ts
+++ b/strings/types/index.ts
@@ -129,6 +129,16 @@ export interface StringMap {
   'browseScreen.updatedTo': 'string';
   'browseScreen.settings.title': 'string';
   'browseScreen.settings.description': 'string';
+  'browseScreen.incompatible.append': 'string';
+  'browseScreen.incompatible.updateTitle': 'string';
+  'browseScreen.incompatible.installTitle': 'string';
+  'browseScreen.incompatible.updateText1': 'string';
+  'browseScreen.incompatible.installText1': 'string';
+  'browseScreen.incompatible.text2': 'string';
+  'browseScreen.incompatible.text3': 'string';
+  'browseScreen.incompatible.text4': 'string';
+  'browseScreen.incompatible.text5': 'string';
+  'browseScreen.incompatible.text6': 'string';
   'browseSettings': 'string';
   'browseSettingsScreen.concurrentSearches': 'string';
   'browseSettingsScreen.multi': 'string';


### PR DESCRIPTION
This is a future-proofing measure: if, according to my proposal, an `api` version field is attached to plugins to manage breaking changes to the plugin API, older versions of the app should be able to detect and reject plugins for newer API versions. No sophisticated logic is required for now: as long as the very first stable 2.0 release has this feature, users won't be confused once plugin version starts actually being used later.