### PR TITLE
feat(plugins): add Cloudflare fetch fallback and cookies API

### DIFF
--- a/src/plugins/helpers/fetch.ts
+++ b/src/plugins/helpers/fetch.ts
@@ -40,12 +40,98 @@ const makeInit = (init?: FetchInit) => {
   return init;
 };
 
+const headersToObject = (
+  headers?: Record<string, string> | Headers,
+): Record<string, string> => {
+  const out: Record<string, string> = {};
+  if (!headers) {
+    return out;
+  }
+  if (headers instanceof Headers) {
+    headers.forEach((value, key) => {
+      out[key] = value;
+    });
+    return out;
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === 'string') {
+      out[key] = value;
+    }
+  }
+  return out;
+};
+
+const isCloudflareChallengeBody = (body: string): boolean =>
+  /Just a moment\.\.\.|cf_chl_opt|challenge-platform|cf-mitigated/i.test(body);
+
+const cacheDir =
+  NativeFile.getConstants().ExternalCachesDirectoryPath ?? '/data/local/tmp';
+
+let webFetchSeq = 0;
+
+const webFetch = async (
+  url: string,
+  init: FetchInit,
+): Promise<Response | undefined> => {
+  const tempPath = `${cacheDir}/web_fetch_${Date.now()}_${webFetchSeq++}.bin`;
+  try {
+    await NativeFile.downloadFile(
+      url,
+      tempPath,
+      init.method || 'get',
+      headersToObject(init.headers),
+      init.body?.toString(),
+    );
+    if (!NativeFile.exists(tempPath)) {
+      return undefined;
+    }
+    const text = NativeFile.readFile(tempPath);
+    return new Response(text, { status: 200 });
+  } catch {
+    return undefined;
+  } finally {
+    try {
+      if (NativeFile.exists(tempPath)) {
+        NativeFile.unlink(tempPath);
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+};
+
 export const fetchApi = async (
   url: string,
   init?: FetchInit,
 ): Promise<Response> => {
-  init = makeInit(init);
-  return await fetch(url, init);
+  const finalInit = makeInit(init);
+  const response = await fetch(url, finalInit);
+  const status = response.status;
+  if (status !== 403 && status !== 503) {
+    return response;
+  }
+  const contentType = response.headers.get('content-type') || '';
+  if (!/text\/html/i.test(contentType)) {
+    return response;
+  }
+  const cloned = response.clone();
+  const body = await cloned.text();
+  if (!isCloudflareChallengeBody(body)) {
+    return new Response(body, {
+      status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  }
+  const retried = await webFetch(url, finalInit);
+  if (retried) {
+    return retried;
+  }
+  return new Response(body, {
+    status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
 };
 
 const FILE_READER_PREFIX_LENGTH = 'data:application/octet-stream;base64,'

--- a/src/plugins/pluginManager.ts
+++ b/src/plugins/pluginManager.ts
@@ -5,6 +5,7 @@ import { load } from 'cheerio';
 import { Parser } from 'htmlparser2';
 import { reverse, uniqBy } from 'lodash-es';
 import { encode, decode } from 'urlencode';
+import CookieManager from '@preeternal/react-native-cookie-manager';
 
 import { getRepositoriesFromDb } from '@database/queries/RepositoryQueries';
 import { getUserAgent } from '@hooks/persisted/useUserAgent';
@@ -25,6 +26,30 @@ import { downloadFile, fetchApi, fetchProto, fetchText } from './helpers/fetch';
 import { FilterTypes } from './types/filterTypes';
 import { isUrlAbsolute } from './helpers/isAbsoluteUrl';
 
+const cookies = {
+  /**
+   * Read cookies for a given URL from the shared WebView/HTTP cookie store.
+   * Returns an object keyed by cookie name with `{ value }` entries.
+   */
+  get: (url: string, useWebKit?: boolean) =>
+    CookieManager.get(url, useWebKit ?? false),
+  /** Set a single cookie for the given URL in the shared store. */
+  set: (
+    url: string,
+    cookie: {
+      name: string;
+      value: string;
+      domain?: string;
+      path?: string;
+      secure?: boolean;
+    },
+    useWebKit?: boolean,
+  ) => CookieManager.set(url, cookie, useWebKit ?? false),
+  /** Clear cookies for a given domain (or all domains). */
+  clearByName: (url: string, name: string, useWebKit?: boolean) =>
+    CookieManager.clearByName(url, name, useWebKit ?? false),
+};
+
 const packages: Record<string, any> = {
   'htmlparser2': { Parser },
   'cheerio': { load },
@@ -37,6 +62,7 @@ const packages: Record<string, any> = {
   '@libs/defaultCover': { defaultCover },
   '@libs/aes': { gcm },
   '@libs/utils': { utf8ToBytes, bytesToUtf8 },
+  '@libs/cookies': { cookies },
 };
 
 const initPlugin = (pluginId: string, rawCode: string) => {


### PR DESCRIPTION
## Summary

Plugins frequently target Cloudflare-protected sites, and the JS fetch implementation on Android cannot survive interstitial challenges. This PR adds two complementary pieces:

1. **Cloudflare fallback in `fetchApi`** ([src/plugins/helpers/fetch.ts](https://github.com/lnreader/lnreader/blob/master/src/plugins/helpers/fetch.ts)) — when a `403` or `503` `text/html` response matches a Cloudflare challenge body (`cf_chl_opt`, "Just a moment...", `challenge-platform`, `cf-mitigated`), retry via `NativeFile.downloadFile` (`webFetch`). The platform HTTP stack tends to clear most challenges. On success the retry response is returned; otherwise the original body is preserved with the original status, so callers see no regression in the failure path.
2. **`@libs/cookies` API for plugins** ([src/plugins/pluginManager.ts](https://github.com/lnreader/lnreader/blob/master/src/plugins/pluginManager.ts)) — expose `get` / `set` / `clearByName` via `@preeternal/react-native-cookie-manager`, backed by the shared WebView/HTTP cookie store. Pairs with the Cloudflare retry so plugin code can capture session cookies and reuse them on subsequent same-origin requests.

## Why

A growing number of source sites sit behind Cloudflare. Currently those plugins fail with the challenge HTML body, with no recourse for users. The fallback uses the Android OkHttp-backed downloader which respects the same WebView cookie jar that already authenticates the user, so a single round trip is usually enough to clear the interstitial.

## Test plan
- [ ] Install a plugin pointing at a Cloudflare-protected source.
- [ ] Confirm fetching the homepage / a chapter previously failing with 403/503 now returns content.
- [ ] In a plugin body, `const { cookies } = require('@libs/cookies')` and verify `get/set/clearByName` round-trip a cookie via the WebView store.
- [ ] Non-Cloudflare requests take the fast path (no observable behavior change for normal 2xx responses).

## Notes
- Detection uses a fixed regex over the response body; if Cloudflare changes its boilerplate the regex may need updating.
- `webFetch` writes to `ExternalCachesDirectoryPath` (or `/data/local/tmp` fallback) and `unlink`s the temp file in `finally`.
- No new dependency added beyond `@preeternal/react-native-cookie-manager`, which is already declared in `package.json`.