### PR TITLE
feat(reader): reactive viewport layout + keyboard navigation

### DIFF
--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -39,8 +39,11 @@ window.reader = new (function () {
     10,
   );
   this.chapterHeight = this.chapterElement.scrollHeight + this.paddingTop;
-  this.layoutHeight = window.screen.height;
-  this.layoutWidth = window.screen.width;
+  // Use viewport (CSS pixels) instead of monitor screen so coordinate math
+  // matches `clientX/Y` and works on environments like WSA where the WebView
+  // window can be smaller than the host monitor.
+  this.layoutHeight = window.innerHeight;
+  this.layoutWidth = window.innerWidth;
 
   this.layoutEvent = undefined;
   this.chapterEndingVisible = van.state(false);
@@ -122,6 +125,24 @@ window.reader = new (function () {
     console.warn = console.log;
     console.error = console.log;
   }
+
+  // Track viewport size changes (e.g. WSA window resize, foldable, split-screen)
+  // so click-region math, page counts and scroll amounts stay in sync with the
+  // current WebView size rather than the value captured at first load.
+  let resizeTimer;
+  window.addEventListener('resize', () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+      this.layoutHeight = window.innerHeight;
+      this.layoutWidth = window.innerWidth;
+      if (
+        this.generalSettings.val.pageReader &&
+        typeof calculatePages === 'function'
+      ) {
+        calculatePages();
+      }
+    }, 150);
+  });
   // end reader
 })();
 
@@ -758,6 +779,69 @@ window.addEventListener('load', () => {
         e.preventDefault();
         reader.post({ type: 'prev' });
       }
+    }
+  });
+})();
+
+// keyboard handler (desktop / WSA: PgUp / PgDown / arrows / space)
+(function () {
+  const isEditableTarget = el => {
+    if (!el) {
+      return false;
+    }
+    const tag = el.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+      return true;
+    }
+    return el.isContentEditable === true;
+  };
+
+  document.addEventListener('keydown', e => {
+    if (isEditableTarget(e.target)) {
+      return;
+    }
+    if (e.ctrlKey || e.metaKey || e.altKey) {
+      return;
+    }
+
+    if (reader.generalSettings.val.pageReader) {
+      if (
+        e.key === 'PageDown' ||
+        e.key === 'ArrowRight' ||
+        e.key === ' ' ||
+        e.key === 'Spacebar'
+      ) {
+        e.preventDefault();
+        pageReader.movePage(pageReader.page.val + 1);
+        return;
+      }
+      if (e.key === 'PageUp' || e.key === 'ArrowLeft') {
+        e.preventDefault();
+        pageReader.movePage(pageReader.page.val - 1);
+        return;
+      }
+      return;
+    }
+
+    if (
+      e.key === 'PageDown' ||
+      e.key === 'ArrowDown' ||
+      e.key === ' ' ||
+      e.key === 'Spacebar'
+    ) {
+      e.preventDefault();
+      window.scrollBy({
+        top: reader.layoutHeight * 0.75,
+        behavior: 'smooth',
+      });
+      return;
+    }
+    if (e.key === 'PageUp' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      window.scrollBy({
+        top: -reader.layoutHeight * 0.75,
+        behavior: 'smooth',
+      });
     }
   });
 })();

--- a/src/screens/reader/components/ReaderFooter.tsx
+++ b/src/screens/reader/components/ReaderFooter.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Pressable, StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, View, useWindowDimensions } from 'react-native';
 import { IconButton } from 'react-native-paper';
 import color from 'color';
 import Animated, {
@@ -10,7 +10,6 @@ import Animated, {
 import { BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
 import { ChapterScreenProps } from '@navigators/types';
 import { useChapterContext } from '../ChapterContext';
-import { SCREEN_HEIGHT } from '@gorhom/bottom-sheet';
 import { useNovelContext } from '@screens/novel/NovelContext';
 import { useTheme } from '@hooks/persisted';
 
@@ -38,11 +37,16 @@ const ChapterFooter = ({
     radius: 50,
   };
   const { navigationBarHeight } = useNovelContext();
+  // Use reactive viewport height so footer animation targets stay correct
+  // when the host window is resized (e.g. WSA, foldables, split-screen).
+  // The previous SCREEN_HEIGHT constant from @gorhom/bottom-sheet captures
+  // the value at module load and never updates.
+  const { height: screenHeight } = useWindowDimensions();
 
   const entering = () => {
     'worklet';
     const animations = {
-      originY: withTiming(SCREEN_HEIGHT - navigationBarHeight - 64, {
+      originY: withTiming(screenHeight - navigationBarHeight - 64, {
         duration: 250,
         easing: fastOutSlowIn,
         reduceMotion: ReduceMotion.System,
@@ -50,7 +54,7 @@ const ChapterFooter = ({
       opacity: withTiming(1, { duration: 150 }),
     };
     const initialValues = {
-      originY: SCREEN_HEIGHT - 64,
+      originY: screenHeight - 64,
       opacity: 0,
     };
     return {
@@ -61,7 +65,7 @@ const ChapterFooter = ({
   const exiting = () => {
     'worklet';
     const animations = {
-      originY: withTiming(SCREEN_HEIGHT - 64, {
+      originY: withTiming(screenHeight - 64, {
         duration: 250,
         easing: fastOutSlowIn,
         reduceMotion: ReduceMotion.System,
@@ -69,7 +73,7 @@ const ChapterFooter = ({
       opacity: withTiming(0, { duration: 150 }),
     };
     const initialValues = {
-      originY: SCREEN_HEIGHT - navigationBarHeight - 64,
+      originY: screenHeight - navigationBarHeight - 64,
       opacity: 1,
     };
     return {


### PR DESCRIPTION
## Summary

Reader UI assumed a fixed viewport captured at first render. A few host environments break that assumption — Windows Subsystem for Android (WSA), foldables, freeform multi-window, split-screen — so click-zone classification, page count, scroll amounts and the bottom-menu animation all kept the original viewport values after the host window changed size. There was also no keyboard support, which is the dominant input on desktop-class hosts like WSA.

This PR makes the reader layout reactive to viewport changes and adds keyboard page navigation.

### `android/app/src/main/assets/js/core.js`

- **Viewport units**: `reader.layoutWidth/layoutHeight` now read `window.innerWidth/innerHeight` instead of `window.screen.width/height`. `window.screen` on Android returns the host monitor resolution (which on WSA stays at the desktop monitor size), not the WebView area, so it never matched `clientX/clientY` and never updated. Fixing this restores correct click-zone classification, scroll deltas and `totalPages` math in `calculatePages()`.
- **Resize listener** (150 ms debounce): re-reads viewport, and in paged mode re-runs `calculatePages()` so column-based pagination follows the new width.
- **Keyboard handler** with `INPUT/TEXTAREA/SELECT/contentEditable` and Ctrl/Alt/Meta guards:
  - Paged mode: PgDown / ArrowRight / Space → next page; PgUp / ArrowLeft → previous page.
  - Scroll mode: PgDown / ArrowDown / Space → +75% viewport scroll; PgUp / ArrowUp → −75%.

### `src/screens/reader/components/ReaderFooter.tsx`

- Replace `SCREEN_HEIGHT` from `@gorhom/bottom-sheet` (captured once at module load via `Dimensions.get('window').height`) with `useWindowDimensions().height`. The entering/exiting worklets target `screenHeight - navigationBarHeight - 64` and `screenHeight - 64`; once the host window shrank, those targets fell off-screen and the bottom menu either drew at the previous viewport's bottom or never became visible.

## Why

Tested on WSA where the host can be resized at any time. Before:
- Centre-of-screen tap classified as "left" because `clientX / screen.width` collapsed the entire WSA window into the leftmost ~50% of the original monitor → menu never opened in paged mode and pages never advanced.
- After resizing, the bottom menu animated to the previous viewport's bottom (off-screen).
- No keyboard navigation — desktop users had no usable input.

After: all three flows behave as expected. On phones / fixed-size devices behaviour is unchanged — `innerWidth/Height` equals the device width/height when the app is full-screen, the resize listener never fires, and the keyboard handler simply has no events to react to.

## Test plan
- [ ] Phone: open a chapter; tap each click region in paged + scroll mode; swipe paged mode; pull bottom menu — no regression.
- [ ] WSA: open a chapter in paged mode; resize the WSA window; click centre → menu toggles using the new viewport.
- [ ] WSA: PgDown / PgUp / ArrowLeft / ArrowRight / Space all advance/retreat one page in paged mode.
- [ ] WSA: scroll mode + resize → bottom menu enters and exits at the bottom of the *current* viewport.
- [ ] Keyboard handler ignores key presses while focus is inside an `<input>` / `<textarea>` / `contentEditable` element, and ignores Ctrl/Alt/Meta combos so browser shortcuts (zoom, dev tools) keep working.

## Notes
- 150 ms `resize` debounce avoids hammering `calculatePages()` during continuous drag.
- No new dependencies; both files only swap to APIs that already ship with React Native / the WebView.
- Pure UI fix; database / fetch / plugin code is untouched.