### PR TITLE
fix(browse): use gesture-handler Pressable in PluginListItem

### DIFF
--- a/src/screens/browse/components/PluginListItem.tsx
+++ b/src/screens/browse/components/PluginListItem.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useCallback, useMemo, useState } from 'react';
-import { Pressable, Image, View, Text, StyleSheet } from 'react-native';
+import { Image, View, Text, StyleSheet } from 'react-native';
+import { Pressable } from 'react-native-gesture-handler';
 import Swipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
 
 import { usePlugins } from '@hooks/persisted';


### PR DESCRIPTION
## Summary

The plugin row in **Browse → Installed** sits inside a `react-native-gesture-handler` `Swipeable` but used the React Native `Pressable`, whose JS responder system is independent of gesture-handler's. On Windows Subsystem for Android (WSA), where taps come from a mouse-derived input pipeline, the `Swipeable`'s gesture-handler responder absorbs the down-event and the JS `Pressable.onPress` never fires — so plugin rows look like dead taps and the user can never enter the SourceScreen.

The fix is one line: import `Pressable` from `react-native-gesture-handler` instead of `react-native`, so taps share the same responder system as the surrounding `Swipeable`.

## Why

- WSA mouse → touch translation routes events into the gesture-handler tree first; the RN-side `Pressable` only sees them if gesture-handler explicitly forwards.
- On regular phones the bug is not visible because the touch sequence is short enough that both responders see the same gesture and `Pressable.onPress` fires.
- gesture-handler's `Pressable` is API-compatible with the RN one for the props this row uses (`onPress`, `style`, `android_ripple`, etc.), so behaviour on phones is unchanged.

## Files changed

- [`src/screens/browse/components/PluginListItem.tsx`](src/screens/browse/components/PluginListItem.tsx) — swap the `Pressable` import (1 file, +2 / -1).

## Test plan
- [ ] Phone: open **Browse → Installed**, tap any installed plugin → SourceScreen opens (no regression).
- [ ] Phone: long-press / swipe row gestures (uninstall) still work.
- [ ] WSA: open **Browse → Installed**, click any plugin row with the mouse → SourceScreen opens.
- [ ] Disabled-plugin / loading skeleton states unchanged.

## Notes
- This was the original intent of [tinywind/lnreader@6f6b313](https://github.com/tinywind/lnreader/commit/6f6b313255699f7f6651e4f24a53a85cdef404e1); cherry-picked clean onto current `master`.
- No new dependencies — `react-native-gesture-handler` is already a dependency.