### PR TITLE
fix:await database operations inside transactions

### DIFF
--- a/src/database/queries/CategoryQueries.ts
+++ b/src/database/queries/CategoryQueries.ts
@@ -156,7 +156,8 @@ export const updateCategory = async (
     await tx
       .update(categorySchema)
       .set({ name: categoryName })
-      .where(eq(categorySchema.id, categoryId));
+      .where(eq(categorySchema.id, categoryId))
+      .run();
   });
 };
 
@@ -186,7 +187,8 @@ export const updateCategoryOrderInDb = async (
 
   await dbManager.write(async tx => {
     for (const category of categories) {
-      tx.update(categorySchema)
+      await tx
+        .update(categorySchema)
         .set({ sort: category.sort })
         .where(eq(categorySchema.id, category.id))
         .run();
@@ -231,7 +233,8 @@ export const _restoreCategory = async (
     // Insert novel-category associations
     if (category.novelIds && category.novelIds.length > 0) {
       for (const novelId of category.novelIds) {
-        tx.insert(novelCategorySchema)
+        await tx
+          .insert(novelCategorySchema)
           .values({
             categoryId: category.id,
             novelId: novelId,

--- a/src/database/queries/ChapterQueries.ts
+++ b/src/database/queries/ChapterQueries.ts
@@ -93,7 +93,8 @@ export const insertChapters = async (
 
 export const markChapterRead = async (chapterId: number): Promise<void> => {
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({ unread: false })
       .where(eq(chapterSchema.id, chapterId))
       .run();
@@ -105,7 +106,8 @@ export const markChaptersRead = async (chapterIds: number[]): Promise<void> => {
     return;
   }
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({ unread: false })
       .where(inArray(chapterSchema.id, chapterIds))
       .run();
@@ -114,7 +116,8 @@ export const markChaptersRead = async (chapterIds: number[]): Promise<void> => {
 
 export const markChapterUnread = async (chapterId: number): Promise<void> => {
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({ unread: true })
       .where(eq(chapterSchema.id, chapterId))
       .run();
@@ -128,7 +131,8 @@ export const markChaptersUnread = async (
     return;
   }
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({ unread: true })
       .where(inArray(chapterSchema.id, chapterIds))
       .run();
@@ -137,7 +141,8 @@ export const markChaptersUnread = async (
 
 export const markAllChaptersRead = async (novelId: number): Promise<void> => {
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({ unread: false })
       .where(eq(chapterSchema.novelId, novelId))
       .run();
@@ -146,7 +151,8 @@ export const markAllChaptersRead = async (novelId: number): Promise<void> => {
 
 export const markAllChaptersUnread = async (novelId: number): Promise<void> => {
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({ unread: true })
       .where(eq(chapterSchema.novelId, novelId))
       .run();
@@ -174,7 +180,8 @@ export const deleteChapter = async (
 ): Promise<void> => {
   deleteDownloadedFiles(pluginId, novelId, chapterId);
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({ isDownloaded: false })
       .where(eq(chapterSchema.id, chapterId))
       .run();
@@ -196,7 +203,8 @@ export const deleteChapters = async (
   );
 
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({ isDownloaded: false })
       .where(inArray(chapterSchema.id, chapterIds))
       .run();
@@ -217,7 +225,7 @@ export const deleteDownloads = async (
     deleteDownloadedFiles(chapter.pluginId, chapter.novelId, chapter.id);
   });
   await dbManager.write(async tx => {
-    tx.update(chapterSchema).set({ isDownloaded: false }).run();
+    await tx.update(chapterSchema).set({ isDownloaded: false }).run();
   });
 };
 
@@ -229,7 +237,8 @@ export const deleteReadChaptersFromDb = async (): Promise<void> => {
   const chapterIds = chapters?.map(chapter => chapter.id);
   if (chapterIds?.length) {
     await dbManager.write(async tx => {
-      tx.update(chapterSchema)
+      await tx
+        .update(chapterSchema)
         .set({ isDownloaded: false })
         .where(inArray(chapterSchema.id, chapterIds))
         .run();
@@ -243,7 +252,8 @@ export const updateChapterProgress = async (
   progress: number,
 ): Promise<void> => {
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({ progress })
       .where(eq(chapterSchema.id, chapterId))
       .run();
@@ -258,7 +268,8 @@ export const updateChapterProgressByIds = async (
     return;
   }
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({ progress })
       .where(inArray(chapterSchema.id, chapterIds))
       .run();
@@ -267,7 +278,8 @@ export const updateChapterProgressByIds = async (
 
 export const bookmarkChapter = async (chapterId: number): Promise<void> => {
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({ bookmark: sql`NOT ${chapterSchema.bookmark}` })
       .where(eq(chapterSchema.id, chapterId))
       .run();
@@ -279,7 +291,8 @@ export const markPreviuschaptersRead = async (
   novelId: number,
 ): Promise<void> => {
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({ unread: false })
       .where(
         and(
@@ -296,7 +309,8 @@ export const markPreviousChaptersUnread = async (
   novelId: number,
 ): Promise<void> => {
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({ unread: true })
       .where(
         and(
@@ -310,7 +324,7 @@ export const markPreviousChaptersUnread = async (
 
 export const clearUpdates = async (): Promise<void> => {
   await dbManager.write(async tx => {
-    tx.update(chapterSchema).set({ updatedTime: null }).run();
+    await tx.update(chapterSchema).set({ updatedTime: null }).run();
   });
 };
 

--- a/src/database/queries/HistoryQueries.ts
+++ b/src/database/queries/HistoryQueries.ts
@@ -32,7 +32,8 @@ export const getHistoryFromDb = async () => {
  */
 export const insertHistory = async (chapterId: number): Promise<void> => {
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({
         readTime: sql`datetime('now','localtime')`,
       })
@@ -48,7 +49,8 @@ export const deleteChapterHistory = async (
   chapterId: number,
 ): Promise<void> => {
   await dbManager.write(async tx => {
-    tx.update(chapterSchema)
+    await tx
+      .update(chapterSchema)
       .set({ readTime: null })
       .where(eq(chapterSchema.id, chapterId))
       .run();
@@ -60,7 +62,7 @@ export const deleteChapterHistory = async (
  */
 export const deleteAllHistory = async (): Promise<void> => {
   await dbManager.write(async tx => {
-    tx.update(chapterSchema).set({ readTime: null }).run();
+    await tx.update(chapterSchema).set({ readTime: null }).run();
   });
   showToast(getString('historyScreen.deleted'));
 };

--- a/src/database/queries/NovelQueries.ts
+++ b/src/database/queries/NovelQueries.ts
@@ -203,12 +203,14 @@ export const removeNovelsFromLibrary = async (novelIds: Array<number>) => {
   if (!novelIds.length) return;
 
   await dbManager.write(async tx => {
-    tx.update(novelSchema)
+    await tx
+      .update(novelSchema)
       .set({ inLibrary: false })
       .where(inArray(novelSchema.id, novelIds))
       .run();
 
-    tx.delete(novelCategorySchema)
+    await tx
+      .delete(novelCategorySchema)
       .where(inArray(novelCategorySchema.novelId, novelIds))
       .run();
   });
@@ -225,7 +227,7 @@ export const getCachedNovels = async (): Promise<NovelInfo[]> => {
 
 export const deleteCachedNovels = async () => {
   await dbManager.write(async tx => {
-    tx.delete(novelSchema).where(eq(novelSchema.inLibrary, false)).run();
+    await tx.delete(novelSchema).where(eq(novelSchema.inLibrary, false)).run();
   });
   showToast(getString('advancedSettingsScreen.cachedNovelsDeletedToast'));
 };
@@ -299,7 +301,8 @@ export const restoreLibrary = async (novel: NovelInfo) => {
 
 export const updateNovelInfo = async (info: NovelInfo) => {
   await dbManager.write(async tx => {
-    tx.update(novelSchema)
+    await tx
+      .update(novelSchema)
       .set({
         name: info.name,
         cover: info.cover || '',
@@ -330,7 +333,8 @@ export const pickCustomNovelCover = async (novel: NovelInfo) => {
     NativeFile.copyFile(image.assets[0].uri, novelCoverUri);
     novelCoverUri += '?' + Date.now();
     await dbManager.write(async tx => {
-      tx.update(novelSchema)
+      await tx
+        .update(novelSchema)
         .set({ cover: novelCoverUri })
         .where(eq(novelSchema.id, novel.id))
         .run();
@@ -345,7 +349,8 @@ export const updateNovelCategoryById = async (
 ) => {
   await dbManager.write(async tx => {
     for (const categoryId of categoryIds) {
-      tx.insert(novelCategorySchema)
+      await tx
+        .insert(novelCategorySchema)
         .values({ novelId, categoryId })
         .onConflictDoNothing()
         .run();
@@ -377,7 +382,8 @@ export const updateNovelCategories = async (
     if (categoryIds.length) {
       for (const novelId of novelIds) {
         for (const categoryId of categoryIds) {
-          tx.insert(novelCategorySchema)
+          await tx
+            .insert(novelCategorySchema)
             .values({ novelId, categoryId })
             .onConflictDoNothing()
             .run();
@@ -401,7 +407,8 @@ export const updateNovelCategories = async (
             .get();
 
           if (!hasCategory || hasCategory.count === 0) {
-            tx.insert(novelCategorySchema)
+            await tx
+              .insert(novelCategorySchema)
               .values({
                 novelId: novelId,
                 categoryId: defaultCategory.id,
@@ -421,11 +428,14 @@ export const _restoreNovelAndChapters = async (backupNovel: BackupNovel) => {
   const { chapters, ...novel } = backupNovel;
   await dbManager.write(async tx => {
     // Delete existing novel data
-    tx.delete(novelSchema).where(eq(novelSchema.id, novel.id)).run();
-    tx.delete(chapterSchema).where(eq(chapterSchema.novelId, novel.id)).run();
+    await tx.delete(novelSchema).where(eq(novelSchema.id, novel.id)).run();
+    await tx
+      .delete(chapterSchema)
+      .where(eq(chapterSchema.novelId, novel.id))
+      .run();
 
     // Restore novel
-    tx
+    await tx
       .insert(novelSchema)
       .values({
         ...novel,
@@ -440,7 +450,7 @@ export const _restoreNovelAndChapters = async (backupNovel: BackupNovel) => {
       const BATCH_SIZE = 100;
       for (let i = 0; i < chapters.length; i += BATCH_SIZE) {
         const batch = chapters.slice(i, i + BATCH_SIZE);
-        tx.insert(chapterSchema).values(batch).run();
+        await tx.insert(chapterSchema).values(batch).run();
       }
     }
   });

--- a/src/services/updates/LibraryUpdateQueries.ts
+++ b/src/services/updates/LibraryUpdateQueries.ts
@@ -43,7 +43,8 @@ const updateNovelMetadata = async (
   }
 
   await dbManager.write(async tx => {
-    tx.update(novelSchema)
+    await tx
+      .update(novelSchema)
       .set({
         name,
         cover: cover || null,
@@ -64,7 +65,8 @@ const updateNovelMetadata = async (
  */
 const updateNovelTotalPages = async (novelId: number, totalPages: number) => {
   await dbManager.write(async tx => {
-    tx.update(novelSchema)
+    await tx
+      .update(novelSchema)
       .set({ totalPages })
       .where(eq(novelSchema.id, novelId))
       .run();


### PR DESCRIPTION
### What does this PR do?
This PR fixes numerous "floating promises" inside `dbManager.write` transactions across the app where database mutations (`tx.insert`, `tx.update`, `tx.delete`) were missing the `await` keyword.


### Changes made
- Added `await` to isolated mutations and loop operations in `NovelQueries.ts`, `ChapterQueries.ts`, `CategoryQueries.ts`, `HistoryQueries.ts`, and `LibraryUpdateQueries.ts`.
- Added the missing `.run()` execution command to `updateCategory` which was previously relying on implicit Drizzle Thenables.
